### PR TITLE
fix:修复初始化项目时，ConfigProvider antdLocale报错

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -21,7 +21,7 @@ export default ()=>{
       cookieLocaleKey: 'lang',
       localStorageLocaleKey:'lang'
     })||navigator.language;
-    changeSystemLanguage(currentLocale);
+    changeSystemLanguage(currentLocale.toLowerCase());
     fecthUserInfo();
   },[])
   return (


### PR DESCRIPTION
初始化时，navigator.language赋值给currentLocale为zh-CN，locale识别的是zh-cn，intl从localstore里取的是zh-CN，导致不一致，只要清空你的浏览器localsotre里面的数据，就会出现上面报错，我的浏览器是这种情况，不知道作者是否是此种情况